### PR TITLE
macro_directive: support description

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -333,7 +333,7 @@ module.exports = grammar({
       command($, "unsubscribe", $._group, choice("*", $._regexes)),
 
     sequence: ($) => $._string,
-    macro_directive: ($) => command($, "macro", $._maps, $.key, $.sequence),
+    macro_directive: ($) => command($, "macro", $._maps, $.key, $.sequence, optional($.description)),
     unmacro_directive: ($) =>
       command($, "unmacro", choice("*", $._maps), $.key),
 

--- a/test/corpus/example.txt
+++ b/test/corpus/example.txt
@@ -15,6 +15,7 @@ mailboxes $spool_file $postponed $record $trash \
 +[Gmail]/Spam +[Gmail]/Starred
 sidebar_unpin *
 source ~/.config/neomutt/neomuttrc
+macro index D '<save-message>+Trash<enter>' 'move message to the trash'
 
 ---
 
@@ -79,4 +80,12 @@ source ~/.config/neomutt/neomuttrc
   (source_directive
     (command)
     (path
-      (shell))))
+      (shell)))
+  (macro_directive
+    (command)
+    (map)
+    (key)
+    (sequence
+      content: (string))
+    (description
+      content: (string))))


### PR DESCRIPTION
[According to the neomutt documentation](https://neomutt.org/guide/configuration.html#10-%C2%A0keyboard-macros), macros support an additonal, optional 'description' argument.

I was not able to regenerate the files properly because my version of tree-sitter-cli (0.20.8-5 on Ubuntu 24.04) [wants to change everything](https://github.com/gagath/tree-sitter-muttrc/commit/acacfcd9211c6af69912ee93e57eaa8a57a7bffe).